### PR TITLE
Fix Leaflet example when BENCHMARKING == false

### DIFF
--- a/examples/leaflet/example.js
+++ b/examples/leaflet/example.js
@@ -52,9 +52,11 @@
       function resetLabels(markers) {
 
         labelEngine.destroy();
+        var i = 0;
         markers.eachLayer(function(label){
-          addLabel(label)
-        ;});
+          addLabel(label, i);
+          i++;
+        });
         labelEngine.update();
 
       }


### PR DESCRIPTION
The benchmarking reset labels function passed a counter into addLabel(), but the non-benchmarking version did not. This adds the counter.