### PR TITLE
Add https to OSM layer

### DIFF
--- a/docs/examples/leaflet/example.js
+++ b/docs/examples/leaflet/example.js
@@ -8,7 +8,7 @@ var labelEngine;
 
 // Leaflet map
 var map = L.map("map").setView([0, 0], 6);
-L.tileLayer("//tile.osm.org/{z}/{x}/{y}.png", {
+L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
   attribution: "&copy; <a href=\"https://osm.org/copyright\">OpenStreetMap</a> contributors"
 }).addTo(map);
 


### PR DESCRIPTION
Issues with displaying OSM data through GitHub. (Insecure Resource).
Forcing HTTPS resolves this. (I prefer // but hey - security).
tile.osm.org has no SSL certificate so had to change to the longer form tile.openstreetmap.org