### PR TITLE
Add HTTPS to OSM Layer

### DIFF
--- a/docs/examples/esri-leaflet/example.js
+++ b/docs/examples/esri-leaflet/example.js
@@ -8,7 +8,7 @@ var labelEngine;
 
 // Leaflet map
 var map = L.map("map").setView([0, 0], 6);
-L.tileLayer("//{s}.tile.osm.org/{z}/{x}/{y}.png", {
+L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
   attribution: "&copy; <a href=\"http://osm.org/copyright\">OpenStreetMap</a> contributors"
 }).addTo(map);
 


### PR DESCRIPTION
Issues with displaying OSM data through GitHub. (Insecure Resource).
Forcing HTTPS resolves this. (I prefer // but hey - security).
tile.osm.org has no SSL certificate so had to change to the longer form tile.openstreetmap.org