### PR TITLE
Change the collision logic

### DIFF
--- a/src/labelgun.js
+++ b/src/labelgun.js
@@ -230,8 +230,8 @@ class labelgun {
     for (let i = 0; i < collisions.length; i++) {
       collision = collisions[i];
       if (
-        collision.state === "show" || 
-        collision.weight > label.weight || 
+        (collision.state === "show" &&
+          collision.weight >= label.weight) ||
         collision.isDragged
       ) {
         return false;


### PR DESCRIPTION
In case of many labels overlapping previous behaviour was not ideal.

If there was a "chain" of overlapping labels with weights 3, 2, 1 in a way that 3 was overlapping with 2, and 2 was overlapping with 1, but 3 and 1 had no overlap - it was resulting in only label 3 being shown.

My understanding is that in such case 1 should be also displayed, although it has lower weight than 2, but has no direct overlap with 3. My code changes that behaviour.